### PR TITLE
Feature/python 3.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
 
 # be a good guy and potentially save time
 cache: pip

--- a/broadbean/broadbean.py
+++ b/broadbean/broadbean.py
@@ -1540,7 +1540,7 @@ class Sequence:
         # Then check that elements use the same channels
         specchans = []
         for elem in self._data.values():
-            chans = elem.channels
+            chans = sorted(elem.channels)
             specchans.append(chans)
         if specchans == []:  # case of empty Sequence
             chans = None


### PR DESCRIPTION
Broadbean should run under python 3.6 too. To ensure that, we must test it under python 3.6. This PR achieves that.