### PR TITLE
Drop support for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: python
 python:
-  - "3.5"
   - "3.6"
 
 # be a good guy and potentially save time

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The name: The broad bean is one of my favourite pulses.
 
 ### Formal requirements
 
-The broadbean package only works with python 3.
+The broadbean package only works with python 3.6+
 
 ### Installation
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
         ],
 
     keywords='Pulsebuilding signal processing arbitrary waveforms',


### PR DESCRIPTION
Since QCoDeS already went ahead and dropped python 3.5, we might as well do the same and use f-strings and type hints.