### PR TITLE
Refactor/no more two markers

### DIFF
--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -77,8 +77,8 @@ def test_addArray():
     m2 = np.ones(N)
 
     elem = bb.Element()
-    elem.addArray(1, wfm, SR, m1, m2)
-    elem.addArray(2, wfm, SR, m1)
+    elem.addArray(1, wfm, SR, m1=m1, m2=m2)
+    elem.addArray(2, wfm, SR, m1=m1)
     elem.addArray(3, wfm, SR, m2=m2)
 
     elem.validateDurations()
@@ -91,7 +91,7 @@ def test_addArray():
         elem.validateDurations()
 
     with pytest.raises(ValueError):
-        elem.addArray(1, wfm, SR, m1[:-1])
+        elem.addArray(1, wfm, SR, m1=m1[:-1])
 
     with pytest.raises(ValueError):
         elem.addArray(2, wfm, SR, m2=m2[3:])


### PR DESCRIPTION
Behind the scenes, forged blueprints/waveforms have the form of an np array holding the waveform, marker 1, marker 2, and the time. That does not accomodate for instruments with a different number of markers and it unnecessarilly carries along the time.

This PR changes that array into a dict, making it optional what is carried along.