### PR TITLE
include LICENSE in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Currently, this package is missing its LICENSE.

Problem came up in https://github.com/conda-forge/staged-recipes/pull/12712 which is required for building QCoDeS on conda-forge.