### PR TITLE
integer number of points.

### DIFF
--- a/broadbean/blueprint.py
+++ b/broadbean/blueprint.py
@@ -762,7 +762,7 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
     intdurations = np.zeros(len(newdurations), dtype=int)
 
     for ii, dur in enumerate(newdurations):
-        int_dur = int(round(dur*SR))
+        int_dur = round(dur*SR)
         if int_dur < 2:
             raise SegmentDurationError('Too short segment detected! '
                                        'Segment "{}" at position {} '

--- a/broadbean/blueprint.py
+++ b/broadbean/blueprint.py
@@ -759,10 +759,10 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
     # and raise an exception if the segment ends up with less than
     # two points
 
-    intdurations = np.zeros(len(newdurations))
+    intdurations = np.zeros(len(newdurations), dtype=int)
 
     for ii, dur in enumerate(newdurations):
-        int_dur = round(dur*SR)
+        int_dur = int(round(dur*SR))
         if int_dur < 2:
             raise SegmentDurationError('Too short segment detected! '
                                        'Segment "{}" at position {} '

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -118,8 +118,8 @@ def test_addArray():
 
 
 @settings(max_examples=25)
-@given(SR1=hst.integers(1), SR2=hst.integers(1),
-       N=hst.integers(2), M=hst.integers(2))
+@given(SR1=hst.integers(min_value=1,max_value=25e8), SR2=hst.integers(min_value = 1,max_value = 25e8),
+       N=hst.integers(min_value=2,max_value=25e6), M=hst.integers(min_value=2,max_value=25e6))
 def test_invalid_durations(SR1, SR2, N, M):
     """
     There are soooo many ways to have invalid durations, here
@@ -207,7 +207,7 @@ def test_input_fail1(improper_bp):
 
 
 @settings(max_examples=25)
-@given(SR=hst.integers(1), N=hst.integers(2))
+@given(SR=hst.integers(min_value=1,max_value=25e8), N=hst.integers(min_value=2,max_value=25e6))
 def test_points(SR, N):
     elem = Element()
 


### PR DESCRIPTION
Making sure that the duration is translated into an integer number of points.
This is necessary if broadbean is to be used with numpy > 1.17 