### PR TITLE
Correct TypeError for numpy>1.17

### DIFF
--- a/broadbean/broadbean.py
+++ b/broadbean/broadbean.py
@@ -28,7 +28,7 @@ class PulseAtoms:
 
     @staticmethod
     def sine(freq, ampl, off, phase, SR, npts):
-        time = np.linspace(0, npts/SR, npts, endpoint=False)
+        time = np.linspace(0, npts/SR, int(npts), endpoint=False)
         freq *= 2*np.pi
         return (ampl*np.sin(freq*time+phase)+off)
 
@@ -36,7 +36,7 @@ class PulseAtoms:
     def ramp(start, stop, SR, npts):
         dur = npts/SR
         slope = (stop-start)/dur
-        time = np.linspace(0, dur, npts, endpoint=False)
+        time = np.linspace(0, dur, int(npts), endpoint=False)
         return (slope*time+start)
 
     @staticmethod
@@ -52,7 +52,7 @@ class PulseAtoms:
         Is by default centred in the middle of the interval
         """
         dur = npts/SR
-        time = np.linspace(0, dur, npts, endpoint=False)
+        time = np.linspace(0, dur, int(npts), endpoint=False)
         centre = dur/2
         baregauss = np.exp((-(time-mu-centre)**2/(2*sigma**2)))
         return ampl*baregauss+offset
@@ -67,7 +67,7 @@ class PulseAtoms:
         smooth cutoff by making offsetting the Gaussian so endpoint = 0 and normalizing the hight to 1   
         """
         dur = npts/SR
-        time = np.linspace(0, dur, npts, endpoint=False)
+        time = np.linspace(0, dur, int(npts), endpoint=False)
         centre = dur/2
         baregauss = np.exp((-(time-mu-centre)**2/(2*sigma**2)))-np.exp((-(0-mu-centre)**2/(2*sigma**2)))
         normalization = 1/(1.0-np.exp((-(0-mu-centre)**2/(2*sigma**2))))


### PR DESCRIPTION
We got this error:
```
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```
This arrives for recent numpy version where the number of point **must** be an integer.

I so propose here to add a `int` function on all the linspace of the lib to avoid such error.