### PR TITLE
Fix invalid identity in blueprint.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,10 +143,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,152 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
-docs/build/
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/broadbean/blueprint.py
+++ b/broadbean/blueprint.py
@@ -53,19 +53,18 @@ class BluePrint():
         # Are the lists of matching lengths?
         lenlist = [len(funlist), len(argslist), len(namelist), len(durslist)]
 
-        if len(set(lenlist)) is not 1:
+        if any(l != lenlist[0] for l in lenlist):
             raise ValueError('All input lists must be of same length. '
                              'Received lengths: {}'.format(lenlist))
         # Are the names valid names?
         for name in namelist:
             if not isinstance(name, str):
                 raise ValueError('All segment names must be strings. '
-                                 'Received {}'.format(name))
-            elif name is not '':
-                if name[-1].isdigit():
-                    raise ValueError('Segment names are not allowed to end'
-                                     ' in a number. {} is '.format(name) +
-                                     'therefore not a valid name.')
+                                f'Received {name}.')
+            if name != '' and name[-1].isdigit():
+                raise ValueError('Segment names are not allowed to end'
+                                f' in a number. {name} is '
+                                 'therefore not a valid name.')
 
         self._funlist = funlist
 
@@ -326,11 +325,6 @@ class BluePrint():
         with open(path_to_file, 'r') as fp:
             data_loaded = json.load(fp)
         return cls.blueprint_from_description(data_loaded)
-
-
-
-
-
 
     def _makeWaitDurations(self):
         """
@@ -863,11 +857,11 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
     elapsed_times = np.cumsum([0.0] + list(newdurations))
 
     for pos, spec in enumerate(segmark1):
-        if spec[1] is not 0:
+        if spec[1] != 0:
             ontime = elapsed_times[pos] + spec[0]  # spec is (delay, duration)
             marker1.append((ontime, spec[1]))
     for pos, spec in enumerate(segmark2):
-        if spec[1] is not 0:
+        if spec[1] != 0:
             ontime = elapsed_times[pos] + spec[0]  # spec is (delay, duration)
             marker2.append((ontime, spec[1]))
     msettings = [marker1, marker2]
@@ -878,7 +872,7 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
             chunk = int(np.round(dur*SR))
             marker[ind:ind+chunk] = 1
 
-    output = np.array(output)  # TODO: Why is this sometimes needed?
+    output = np.asarray(output)  # TODO: Why is this sometimes needed?
 
     outdict = {'wfm': output, 'm1': m1, 'm2': m2, 'time': time,
                'newdurations': newdurations}

--- a/broadbean/blueprint.py
+++ b/broadbean/blueprint.py
@@ -843,14 +843,15 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
             newdurations[ii] = int_dur/SR
 
     # The actual forging of the waveform
+    wf_length = np.sum(intdurations)
     parts = [ft.partial(fun, *args) for (fun, args) in zip(funlist, argslist)]
-    blocks = [list(p(SR, d)) for (p, d) in zip(parts, intdurations)]
-    output = [block for sl in blocks for block in sl]
+    blocks = [p(SR, d) for (p, d) in zip(parts, intdurations)]
+    output = np.fromiter((block for sl in blocks for block in sl), float, count=wf_length)
 
     # now make the markers
-    time = np.linspace(0, sum(newdurations), len(output), endpoint=False)
+    time = np.linspace(0, sum(newdurations), wf_length, endpoint=False)
     m1 = np.zeros_like(time)
-    m2 = m1.copy()
+    m2 = np.zeros_like(time)
 
     # update the 'absolute time' marker list with 'relative time'
     # (segment bound) markers converted to absolute time
@@ -871,8 +872,6 @@ def _subelementBuilder(blueprint: BluePrint, SR: int,
             ind = np.abs(time-t).argmin()
             chunk = int(np.round(dur*SR))
             marker[ind:ind+chunk] = 1
-
-    output = np.asarray(output)  # TODO: Why is this sometimes needed?
 
     outdict = {'wfm': output, 'm1': m1, 'm2': m2, 'time': time,
                'newdurations': newdurations}


### PR DESCRIPTION
Fixes several erroneous identity comparisons that are showing up as warnings in Python 3.10 on import. Specifically when comparing `int` and empty strings, `!=` should be used instead of `is not`.

In addition, .gitignore is extended to include extra files/directories from https://github.com/github/gitignore/blob/main/Python.gitignore to support development installs in python. 

@jenshnielsen 