### PR TITLE
Fix requirements formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿# pinned depedancies for CI
+# pinned depedancies for CI
 alabaster~=0.7.12
 argon2-cffi~=21.3.0
 argon2-cffi-bindings~=21.2.0


### PR DESCRIPTION
Remove BOM from requirements.txt, no need to include a BOM and this may break some tools and formatting