### PR TITLE
Require versioningit 2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 56.0",
     "wheel >= 0.29.0",
-    "versioningit ~= 1.1.1",
+    "versioningit ~= 2.0.1",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     numpy>=1.12.1
     matplotlib
     schema
-    versioningit>=1.1.1
+    versioningit>=2.0.1
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Versioningit 2.0.1 adds support for pep660 editable installs that will land in setuptools soon

See https://discuss.python.org/t/pep-660-and-setuptools/14855 for details