### PR TITLE
Mypy ignore_missing_imports improvements

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -54,7 +54,7 @@ jobs:
       run: |
         pip install .
     - name: Run Mypy
-      run: mypy broadbean
+      run: mypy -p broadbean
     - name: Run tests
       run: |
         pytest --cov=broadbean --cov-report xml --hypothesis-profile ci broadbean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,18 @@ minversion = "6.0"
 addopts = "-ra -q"
 
 [tool.mypy]
-ignore_missing_imports = true
 show_error_codes = true
 enable_error_code = "ignore-without-code"
 warn_unused_ignores = true
 warn_unused_configs = true
 warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = [
+    "matplotlib.*",
+    "schema"
+]
+ignore_missing_imports = true
 
 [tool.versioningit]
 default-version = "0.0"


### PR DESCRIPTION
Only allow missing imports for specific modules that we know
don't have types.

Also run mypy against installed broadbean

See matching pr in qcodes https://github.com/QCoDeS/Qcodes/pull/4484 and https://github.com/QCoDeS/Qcodes/pull/4484