### PR TITLE
CI update refs to point to main rather than master

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ name: build docs
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'release/*'
       - 'version1.0'
     tags:
@@ -28,7 +28,7 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
-      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - uses: actions/checkout@v3.0.2
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,7 +3,7 @@ name: Run mypy and pytest
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'release/*'
       - 'version1.0'
     tags:


### PR DESCRIPTION
Looks like these CI references were dropped when the master branch was renamed to main 