### PR TITLE
Drop python 37

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
-            python-version: 3.9
+            python-version: "3.9"
           - os: windows-latest
-            python-version: 3.10
+            python-version: "3.10"
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.8"
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,10 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         exclude:
-          - os: windows-latest
-            python-version: "3.7"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest

--- a/.github/workflows/upload_to_pypi.yaml
+++ b/.github/workflows/upload_to_pypi.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4.3.0
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install build deps
       run: pip install --upgrade pip setuptools wheel build
     - name: Build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -24,7 +23,7 @@ classifiers = [
 ]
 license = {text = "MIT"}
 urls = {Homepage = "https://github.com/QCoDeS/broadbean"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.12.1",
     "matplotlib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,7 @@ idna~=3.4
 imagesize~=1.4.1
 iniconfig~=1.1.1
 ipykernel~=6.16.2
-ipython==8.6.0; python_version>='3.8'
-ipython==7.34.0; python_version<'3.8'
+ipython==8.6.0
 ipython-genutils~=0.2.0
 ipywidgets~=8.0.2
 jedi~=0.18.1
@@ -48,12 +47,10 @@ jupyterlab-pygments~=0.2.2
 jupyterlab-widgets~=3.0.3
 kiwisolver~=1.4.4
 MarkupSafe~=2.1.1
-matplotlib~=3.6.1; python_version>='3.8'
-matplotlib~=3.5.3; python_version<'3.8'
+matplotlib~=3.6.1
 matplotlib-inline~=0.1.6
 mistune~=2.0.4
-numpy~=1.21.5; python_version<'3.8'
-numpy~=1.23.4; python_version>='3.8'
+numpy~=1.23.4
 mypy~=0.982
 mypy-extensions~=0.4.3
 nbclient~=0.7.0


### PR DESCRIPTION
Given that qcodes has dropped 3.7 it makes sense to do it here too. Note that on top of the current dependencies that do not support 3.7 ipykernel has now also dropped it