### PR TITLE
Only open dependabot prs for python when needed

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   rebase-strategy: "disabled"
+  versioning-strategy: increase-if-necessary
 - package-ecosystem: github-actions
   directory: "/"
   rebase-strategy: "disabled"


### PR DESCRIPTION
This should significantly cut down number of pull requests 