### PR TITLE
Revert ipykernel to 6.17 series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ identify~=2.5.8
 idna~=3.4
 imagesize~=1.4.1
 iniconfig~=1.1.1
-ipykernel~=6.18.1
+ipykernel~=6.17.1
 ipython==8.6.0
 ipython-genutils~=0.2.0
 ipywidgets~=8.0.2


### PR DESCRIPTION
6.18 series was yanked due to various bugs 
