### PR TITLE
Use trusted flow for pypi publishing

### DIFF
--- a/.github/workflows/upload_to_pypi.yaml
+++ b/.github/workflows/upload_to_pypi.yaml
@@ -10,6 +10,8 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: pypi-release-env
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3.5.2
     - name: Set up Python
@@ -21,11 +23,5 @@ jobs:
     - name: Build
       run: |
         python -m build
-    - name: Install Twine
-      run: pip install twine
-    - name: Publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload dist/*
+    - name: Publish to pypi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools >= 61.2",
-    "wheel >= 0.29.0",
     "versioningit ~= 2.0.1",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
And remove non needed build time dependency on wheel