### PR TITLE
fix docs build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ numpy~=1.24.0
 mypy~=1.3.0
 mypy-extensions~=1.0.0
 nbclient~=0.8.0
-nbsphinx~=0.9.1
+nbsphinx==0.9.1
 nbconvert~=7.4.0
 nbformat~=5.8.0
 nest-asyncio~=1.5.6


### PR DESCRIPTION
see https://github.com/QCoDeS/Qcodes/pull/5180 for failure

Have not had the time to figure out why this broke but it looks like nbsphinx 0.9.2 has issues with notebooks with internal links in them (tocs)
