### PR TITLE
Unpin versioningit build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 61.2",
-    "versioningit ~= 2.0.1",
+    "versioningit >= 2.0.1",
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
The backstory is that I am switching [nixpkgs](https://github.com/NixOS/nixpkgs) to use [`build`](https://pypa-build.readthedocs.io/en/latest/) to build Python packages, which checks build dependency version constraints (by default). The nixpkgs repository (usually) only keeps the latest version of each package, and versioningit is already at 2.2.0.

Would it be possible to leave the upper bound constraint open until a breakage is observed? I'm also open to any other scheme you prefer.

<!--

Thanks for submitting a pull request against broadbean.

To help us effectively merge your PR please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

If this fixes a known bug reported against broadbean:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the QCoDeS contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
