### PR TITLE
Drop Python 3.11, set minimum to 3.12

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,10 +22,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         exclude:
-          - os: windows-latest
-            python-version: "3.12"
           - os: windows-latest
             python-version: "3.13"
           - os: windows-latest
@@ -33,7 +31,7 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
-      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - uses: actions/checkout@v6.0.2
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,10 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         exclude:
-          - os: windows-latest
-            python-version: "3.12"
           - os: windows-latest
             python-version: "3.13"
           - os: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ cython_debug/
 
 # Mac files
 .DS_Store
+
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -23,7 +22,7 @@ classifiers = [
 ]
 license = {text = "MIT"}
 urls = {Homepage = "https://github.com/QCoDeS/broadbean"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.12.1",
     "matplotlib",


### PR DESCRIPTION
## Changes
- Set requires-python to >=3.12
- Updated classifiers (removed 3.11)
- Updated CI matrix in pytest.yaml and docs.yaml (removed 3.11)
- Updated docs gh-pages deploy to use Python 3.12
- Added uv.lock to .gitignore